### PR TITLE
Change search url constructing func to adapt to the its latest change

### DIFF
--- a/src/components/FuzzySearch.js
+++ b/src/components/FuzzySearch.js
@@ -103,7 +103,7 @@ const FuzzySearchBox = (props) => {
             });
             props.handleSubmitClick({
               fields: fields,
-              text: `(${text.trim()})`,
+              text: text.trim(),
             });
           } else {
             props.handleSubmitClick({ fields: [], text: "" });
@@ -145,7 +145,7 @@ const FuzzySearchBox = (props) => {
           const fields = options.filter((item, index) => {
             return checkedState[index];
           });
-          props.handleSubmitClick({ fields: fields, text: `(${text.trim()})` });
+          props.handleSubmitClick({ fields: fields, text: text.trim() });
         } else {
           props.handleSubmitClick({ fields: [], text: "" });
         }

--- a/src/utils.js
+++ b/src/utils.js
@@ -118,8 +118,8 @@ export const createSearchUrl = async ({
           fuzzySearchPhrase === ""
             ? `(${search})`
             : search === ""
-            ? `(${fuzzySearchPhrase})`
-            : `(${[fuzzySearchPhrase, search].join(" AND ")})`,
+            ? fuzzySearchPhrase
+            : `((${fuzzySearchPhrase}) AND ${search})`,
         select: "start_time,end_time,text,/public/asset_metadata/title",
         start: 0,
         limit: 160,
@@ -137,6 +137,11 @@ export const createSearchUrl = async ({
       } else {
         // only  set the max-total when we are using fuzzy search
         queryParams.max_total = 160;
+      }
+      // for the two pass approach,
+      // if we do not have the exact match filters, we should enable semantic=true
+      if (search === "") {
+        queryParams.semantic = true;
       }
       const url = await client.Rep({
         libraryId,


### PR DESCRIPTION
necessary changes for the new two-pass approach.
But when I search "shaken not stirred" in the BM25 fields, still 45 clips returned. 
Will keep this PR open, please tell me if I'm wrong and I will fix it.